### PR TITLE
Add context()

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![browser support][9]][10]
 
-Fluent pluggable interface for easily wrapping `describe` and `it` blocks in Mocha tests.
+Fluent pluggable interface for easily wrapping `describe`, `context`, and `it` blocks in Mocha tests.
 
 ## Example
 

--- a/index.js
+++ b/index.js
@@ -128,6 +128,11 @@ MochaWrapper.prototype.describe = function describe(msg, fn) {
 	createAssertion('describe', msg, wrappers, fn);
 };
 
+MochaWrapper.prototype.context = function context(msg, fn) {
+	var wrappers = getThisWrappers(checkThis(this));
+	createAssertion('context', msg, wrappers, fn);
+};
+
 var wrap = function wrap() { return new MochaWrapper(); };
 
 var isWithNameAvailable = function (name) {

--- a/test/mocha/core.js
+++ b/test/mocha/core.js
@@ -21,8 +21,10 @@ describe('core MochaWrapper semantics', function () {
 			return { description: 'i am pointless' };
 		};
 
-		wrap().use(withDescriptor).it('accepts a plugin that returns a descriptor', function () {
-			assert.equal(flag, true);
+		wrap().use(withDescriptor).context('with a plugin that returns a descriptor', function () {
+			it('works', function () {
+				assert.equal(flag, true);
+			});
 		});
 
 		wrap().use(withNothing).it('works with a plugin that returns a descriptor with only a description', function () {


### PR DESCRIPTION
According to Mocha documentation, `context()` is just an alias for
`describe()`. Folks might be expecting it to exist on this API, so I am
adding it.
