### PR TITLE
[Breaking] [New] Add `.only()`/`.skip()`, drop mocha < 1.4.1 support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,7 @@
 	"rules": {
 		"id-length": 0,
 		"max-nested-callbacks": [2, 4],
-		"max-params": [2, 4],
+		"max-params": [2, 5],
 		"max-statements": [2, 11],
 		"no-invalid-this": 0,
 		"no-magic-numbers": 0,

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ wrap().withOverrides(obj, { a: 2, b: 3 }).describe('overridden object keys', fun
 		expect(obj.a).to.equal(2);
 	});
 });
+
+wrap().withOverride(obj, 'a', 4).skip().describe('this test is skipped', function () {
+	it('also supports .only()!', function () {
+		expect(true).to.equal(false); // skipped
+	});
+});
 ```
 
 ## Plugins

--- a/README.md
+++ b/README.md
@@ -96,13 +96,16 @@ module.exports = function withFoo(any, args, you, want) {
 };
 ```
 
-Usage:
+## Usage
 ```js
 var wrap = require('mocha-wrap');
 wrap.register(require('mocha-wrap-with-foo'));
 
 wrap().withFoo().describe…
 ```
+
+## skip/only
+Although mocha has `describe.skip`, `describe.only`, `context.skip`, `context.only`, `it.skip`, and `it.only`, it is not possible to implement these in mocha-wrap without using ES5 property accessors. Since this project supports ES3, we decided to use `.skip().describe` etc rather than forfeit the ability to have skip/only.
 
 ## Tests
 Simply clone the repo, `npm install`, and run `npm test`

--- a/index.js
+++ b/index.js
@@ -165,17 +165,35 @@ MochaWrapper.prototype.it = function it(msg, fn) {
 	var mode = getThisMode(this);
 	createAssertion('it', msg, wrappers, fn, mode);
 };
+MochaWrapper.prototype.it.skip = function skip() {
+	throw new SyntaxError('mocha-wrap requires `.skip().it` rather than `it.skip`');
+};
+MochaWrapper.prototype.it.only = function only() {
+	throw new SyntaxError('mocha-wrap requires `.only().it` rather than `it.only`');
+};
 
 MochaWrapper.prototype.describe = function describe(msg, fn) {
 	var wrappers = getThisWrappers(checkThis(this));
 	var mode = getThisMode(this);
 	createAssertion('describe', msg, wrappers, fn, mode);
 };
+MochaWrapper.prototype.describe.skip = function skip() {
+	throw new SyntaxError('mocha-wrap requires `.skip().describe` rather than `describe.skip`');
+};
+MochaWrapper.prototype.describe.only = function only() {
+	throw new SyntaxError('mocha-wrap requires `.only().describe` rather than `describe.only`');
+};
 
 MochaWrapper.prototype.context = function context(msg, fn) {
 	var wrappers = getThisWrappers(checkThis(this));
 	var mode = getThisMode(this);
 	createAssertion('context', msg, wrappers, fn, mode);
+};
+MochaWrapper.prototype.context.skip = function skip() {
+	throw new SyntaxError('mocha-wrap requires `.skip().context` rather than `context.skip`');
+};
+MochaWrapper.prototype.context.only = function only() {
+	throw new SyntaxError('mocha-wrap requires `.only().context` rather than `context.only`');
 };
 
 var wrap = function wrap() { return new MochaWrapper(); };

--- a/package.json
+++ b/package.json
@@ -23,23 +23,27 @@
 		"tests-only": "parallelshell 'npm run --silent tape | faucet' 'npm run --silent mocha1 && npm run --silent mocha2'",
 		"lint": "eslint '**/*.js'",
 		"tape": "node test/tape",
-		"mocha": "mocha test/mocha",
-		"install:mocha1.1": "npm install mocha@1.1.0 && mocha --version",
-		"install:mocha1.x": "npm install mocha@1.x && mocha --version",
-		"install:mocha2.0": "npm install mocha@2.0.0 && mocha --version",
-		"install:mocha2.x": "npm install mocha@2.x && mocha --version",
-		"mocha1.1": "npm run --silent install:mocha1.1 && npm run --silent mocha -- --ignore-leaks",
-		"mocha1.x": "npm run --silent install:mocha1.x && npm run --silent mocha -- --ignore-leaks",
+		"mocha": "npm run --silent mocha:standard && npm run --silent mocha:only",
+		"mocha:standard": "mocha test/mocha --ignore-leaks",
+		"mocha:only": "mocha test/mocha-only",
+		"install:mocha1.4": "npm install --silent mocha@1.4.1 && mocha --version",
+		"install:mocha1.x": "npm install --silent mocha@1.x && mocha --version",
+		"install:mocha2.0": "npm install --silent mocha@2.0.0 && mocha --version",
+		"install:mocha2.x": "npm install --silent mocha@2.x && mocha --version",
+		"mocha1.4": "npm run --silent install:mocha1.4 && npm run --silent mocha",
+		"mocha1.x": "npm run --silent install:mocha1.x && npm run --silent mocha",
 		"mocha2.0": "npm run --silent install:mocha2.0 && npm run --silent mocha",
 		"mocha2.x": "npm run --silent install:mocha2.x && npm run --silent mocha",
-		"mocha1": "npm run --silent mocha1.1 && npm run --silent mocha1.x",
+		"mocha1": "npm run --silent mocha1.4 && npm run --silent mocha1.x",
 		"mocha2": "npm run --silent mocha2.0 && npm run --silent mocha2.x",
 		"cover": "npm run --silent cover:clean && parallelshell 'npm run --silent cover:tape' 'npm run --silent cover:mocha' && npm run --silent cover:merge && npm run --silent cover:check",
 		"cover:clean": "rimraf coverage",
 		"cover:check": "istanbul check-coverage && echo 100% code coverage, achievement unlocked!",
 		"cover:merge": "istanbul-merge --out coverage/coverage.raw.json 'coverage/*/coverage.raw.json' && istanbul report --format html",
 		"cover:tape": "istanbul cover test/tape --dir coverage/tape",
-		"cover:mocha": "istanbul cover ./node_modules/.bin/_mocha --dir coverage/mocha -- test/mocha --recursive --reporter=min"
+		"cover:mocha": "npm run --silent cover:mocha:standard && npm run --silent cover:mocha:only",
+		"cover:mocha:standard": "istanbul cover ./node_modules/.bin/_mocha --dir coverage/mocha -- test/mocha --recursive --reporter=min",
+		"cover:mocha:only": "istanbul cover ./node_modules/.bin/_mocha --dir coverage/mocha-only -- test/mocha-only --recursive --reporter=min"
 	},
 	"repository": {
 		"type": "git",
@@ -83,7 +87,7 @@
 		"function.prototype.name": "^1.0.0"
 	},
 	"peerDependencies": {
-		"mocha": "^1.1.0 || ^2.0.0"
+		"mocha": "^1.4.1 || ^2.0.0"
 	},
 	"devDependencies": {
 		"tape": "^4.5.1",

--- a/test/mocha-only/.eslintrc
+++ b/test/mocha-only/.eslintrc
@@ -1,0 +1,10 @@
+{
+	"globals": {
+		"describe": false,
+		"it": false,
+		"before": false,
+		"beforeEach": false,
+		"after": false,
+		"afterEach": false
+	}
+}

--- a/test/mocha-only/index.js
+++ b/test/mocha-only/index.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var assert = require('assert');
+var wrap = require('../../');
+
+var withNothing = function withNothing() {
+	return this.extend('with nothing', { before: function () {} });
+};
+
+describe('#only()', function () {
+	it('fails', function () {
+		assert.equal(true, false, 'explode!');
+	});
+
+	wrap().use(withNothing).only().it('passes', function () {
+		assert.equal(true, true, 'testing is fun');
+	});
+});

--- a/test/mocha/core.js
+++ b/test/mocha/core.js
@@ -10,6 +10,10 @@ describe('core MochaWrapper semantics', function () {
 		assert['throws'](function () { wrap().it('foo', function () {}); }, RangeError);
 	});
 
+	var withNothing = function withNothing() {
+		return { description: 'i am pointless' };
+	};
+
 	describe('#use()', function () {
 		var flag = false;
 		var withDescriptor = function withDescriptor() {
@@ -18,9 +22,6 @@ describe('core MochaWrapper semantics', function () {
 				beforeEach: function () { flag = true; },
 				afterEach: function () { flag = false; }
 			};
-		};
-		var withNothing = function withNothing() {
-			return { description: 'i am pointless' };
 		};
 
 		wrap().use(withDescriptor).context('with a plugin that returns a descriptor', function () {
@@ -31,6 +32,24 @@ describe('core MochaWrapper semantics', function () {
 
 		wrap().use(withNothing).it('works with a plugin that returns a descriptor with only a description', function () {
 			assert.equal(true, true); // oh yeah, TESTING
+		});
+	});
+
+	describe('#skip()', function () {
+		wrap().use(withNothing).skip().it('skipped an it!', function () {
+			assert.equal(true, false); // boom
+		});
+
+		wrap().use(withNothing).skip().describe('skipped a describe!', function () {
+			it('fails if not skipped', function () {
+				assert.equal(true, false); // boom
+			});
+		});
+
+		wrap().use(withNothing).skip().context('skipped a context!', function () {
+			it('fails if not skipped', function () {
+				assert.equal(true, false); // boom
+			});
 		});
 	});
 

--- a/test/tape/index.js
+++ b/test/tape/index.js
@@ -114,8 +114,8 @@ test('MochaWrapper', function (t) {
 	});
 
 	t.test('visible instance properties', { skip: hasPrivacy }, function (st) {
-		st.deepEqual(Object.keys(instance), ['wrappers'], 'has "wrappers" key');
-		st.deepEqual(Object.keys(described), ['wrappers', 'description'], 'has "wrappers" and "description" keys');
+		st.deepEqual(Object.keys(instance), ['wrappers', 'mode'], 'has "wrappers" and "mode" key');
+		st.deepEqual(Object.keys(described), ['wrappers', 'mode', 'description'], 'has "wrappers", "mode", and "description" keys');
 
 		st.end();
 	});

--- a/test/tape/index.js
+++ b/test/tape/index.js
@@ -34,9 +34,22 @@ test('mocha-wrap', function (t) {
 	setup();
 	t.on('end', teardown);
 
-	t['throws'](function () { wrap().describe('foo', function () {}); }, RangeError, 'throws when there are no transformations');
-	t['throws'](function () { wrap().context('foo', function () {}); }, RangeError, 'throws when there are no transformations');
-	t['throws'](function () { wrap().it('foo', function () {}); }, RangeError, 'throws when there are no transformations');
+	t.test('no transformations', function (st) {
+		st['throws'](function () { wrap().describe('foo', function () {}); }, RangeError, 'throws when there are no transformations');
+		st['throws'](function () { wrap().context('foo', function () {}); }, RangeError, 'throws when there are no transformations');
+		st['throws'](function () { wrap().it('foo', function () {}); }, RangeError, 'throws when there are no transformations');
+		st.end();
+	});
+
+	t.test('{describe,context,it}.{skip,only} throw', function (st) {
+		st['throws'](function () { wrap().describe.skip('skip'); }, SyntaxError, 'describe.skip throws');
+		st['throws'](function () { wrap().describe.only('only'); }, SyntaxError, 'describe.only throws');
+		st['throws'](function () { wrap().context.skip('skip'); }, SyntaxError, 'context.skip throws');
+		st['throws'](function () { wrap().context.only('only'); }, SyntaxError, 'context.only throws');
+		st['throws'](function () { wrap().it.skip('skip'); }, SyntaxError, 'it.skip throws');
+		st['throws'](function () { wrap().it.only('only'); }, SyntaxError, 'it.only throws');
+		st.end();
+	});
 
 	t.test('.supportedMethods', function (st) {
 		st.equal(Array.isArray(wrap.supportedMethods), true, 'is an array');


### PR DESCRIPTION
`mocha` did not get `only` support until v1.4 (broken in v1.4.0). Prior to that, it did have `xdescribe` functionality for `skip`, but since I didn’t want to only have partial support from v1.1 - v1.3, I’m just hiking up the bottom threshold to v1.4.

Fixes #1.
