### PR TITLE
Fix an issue causing multiple wraps to exponentially add outer wrappers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,7 +257,7 @@ MochaWrapper.prototype.use = function use(plugin) {
 		instance = wrap().extend(descriptorOrInstance.description, descriptorOrInstance);
 	}
 
-	return concatThis(this, [instance]);
+	return instance;
 };
 
 wrap.register = function register(plugin) {

--- a/test/mocha/core.js
+++ b/test/mocha/core.js
@@ -14,6 +14,19 @@ describe('core MochaWrapper semantics', function () {
 		return { description: 'i am pointless' };
 	};
 
+	var testingCount = 0;
+	var withTesting = function withTesting() {
+		return this.extend('(with Testing)', {
+			beforeEach: function withTestingBeforeEach() {
+				testingCount += 1;
+			}
+		});
+	};
+
+	var withFancyNoop = function withFancyNoop() {
+		return this.extend('(withFancyNoop)', {});
+	};
+
 	describe('#use()', function () {
 		var flag = false;
 		var withDescriptor = function withDescriptor() {
@@ -23,6 +36,15 @@ describe('core MochaWrapper semantics', function () {
 				afterEach: function () { flag = false; }
 			};
 		};
+
+		wrap()
+		.use(withTesting)
+		.use(withFancyNoop)
+		.context('with multiple plugins', function () {
+			it('calls the plugin\'s hooks an appropriate number of times', function () {
+				assert.equal(testingCount, 1);
+			});
+		});
 
 		wrap().use(withDescriptor).context('with a plugin that returns a descriptor', function () {
 			it('works', function () {


### PR DESCRIPTION
It appears that we were double wrapping MochaWrap instances when calling `.use`
or `.with<Wrapper>` multiple times. When calling `.use`, we were correctly creating
a new instance of MochaWrap with all the correct wrappers, but instead of
returning that new instance, we were appending it (and all its wrappers, which
include all of our current instance's wrappers) to our current instance's
wrappers.

Now we're just extending, and returning the new instance.

This is meant to address - https://github.com/airbnb/mocha-wrap/issues/24